### PR TITLE
Fix substring length parameter in UnicodeSplitter.cs 

### DIFF
--- a/Sms.Splitter/UnicodeSplitter.cs
+++ b/Sms.Splitter/UnicodeSplitter.cs
@@ -76,7 +76,8 @@ namespace Sms.Splitter
             {
                 Bytes = walker.Bytes,
                 Length = walker.Length,
-                Content = partEnd.HasValue ? content.Substring(walker.PartStart, partEnd.Value + 1) : content.Substring(walker.PartStart)
+                //Content = partEnd.HasValue ? content.Substring(walker.PartStart, partEnd.Value + 1) : content.Substring(walker.PartStart)
+                Content = partEnd.HasValue ? content.Substring(walker.PartStart, (partEnd.Value + 1) - walker.PartStart) : content.Substring(walker.PartStart)
             });
             result.TotalBytes += walker.Bytes;
             result.TotalLength += walker.Length;


### PR DESCRIPTION
This is a fix for issue #2, "Normal text after Emoji/Unicode breaks .Split()".
The code threw an unhandled exception sometimes when dealing with special characters, such as emoji, and Sinhalese and Thai characters.